### PR TITLE
Allow use of `--show-column-numbers`

### DIFF
--- a/problem-matcher.json
+++ b/problem-matcher.json
@@ -5,7 +5,7 @@
             "severity": "error",
             "pattern": [
                 {
-                    "regexp": "^([^:]+):(\\d+):\\s+(error:\\s+.+)$",
+                    "regexp": "^([^:]+):(\\d+):(?:\\d+:)?\\s+(error:\\s+.+)$",
                     "file": 1,
                     "line": 2,
                     "message": 3


### PR DESCRIPTION
This allows the use of the `--show-column-numbers` `mypy` flag. 

However, an alternative I would be happy with is for the documentation for this PR annotator to warn that users should specify `--hide-column-numbers` (the default) otherwise the regex will not match error lines. 